### PR TITLE
FIX-#31: Fix test_nans and add mixed sort test

### DIFF
--- a/modin_spreadsheet/grid.py
+++ b/modin_spreadsheet/grid.py
@@ -1165,7 +1165,7 @@ class SpreadsheetWidget(widgets.DOMWidget):
             )
             # Record mixed type column sort
             # Create stringified helper column to sort on
-            helper_col = self._sort_field + self._sort_col_suffix
+            helper_col = str(self._sort_field) + self._sort_col_suffix
             self._record_transformation(
                 (
                     f"{constants.SORT_MIXED_TYPE_COLUMN}\n"

--- a/modin_spreadsheet/tests/test_grid.py
+++ b/modin_spreadsheet/tests/test_grid.py
@@ -1065,22 +1065,22 @@ def test_mixed_type_sort():
         }
     )
 
-    view = SpreadsheetWidget(df=df)
+    spreadsheet = SpreadsheetWidget(df=df)
 
-    view._handle_view_msg_helper(
+    spreadsheet._handle_view_msg_helper(
         {"type": "change_sort", "sort_field": "Mixed", "sort_ascending": True}
     )
 
     expected_order_mixed = [1e10, pd.Timestamp("2017-02-02"), 5, "hey", np.nan]
-    sorted_order_mixed = list(view.get_changed_df()["Mixed"])
+    sorted_order_mixed = list(spreadsheet.get_changed_df()["Mixed"])
     assert expected_order_mixed[:4] == sorted_order_mixed[:4]
     # np.nan != np.nan by definition, so check if value at index 4 are both np.nan
-    assert isnan(expected_order_mixed[4]) and isnan(sorted_order_mixed[4])
+    assert np.isnan(expected_order_mixed[4]) and np.isnan(sorted_order_mixed[4])
 
     # check sorting on number column names works
-    view._handle_view_msg_helper(
+    spreadsheet._handle_view_msg_helper(
         {"type": "change_sort", "sort_field": 1, "sort_ascending": True}
     )
     expected_order_1 = [1, 2, 4, 5, "hello"]
-    sorted_order_1 = list(view.get_changed_df()[1])
+    sorted_order_1 = list(spreadsheet.get_changed_df()[1])
     assert expected_order_1 == sorted_order_1


### PR DESCRIPTION
Resolves #31 test_nans was not working because the column name was an integer and grid.py concatenates a string to column names to ensure unique column names. Fix by casting to string.

Added a test_mixed_type_sort with mixed data types such as np.nan as well as sorting a column with an integer column name.