### PR TITLE
DOCS-#22: Update GitHub links and directory name

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,7 +7,7 @@ to install from source and make local changes to their copy of modin-spreadsheet
 All contributions, bug reports, bug fixes, documentation improvements, enhancements and ideas are welcome.
 We `track issues`__ on `GitHub`__ and that's also the best place to ask any questions you may have.
 
-__ https://github.com/modin-project/qgrid#running-from-source--testing-your-changes
-__ https://github.com/modin-project/qgrid
-__ https://github.com/modin-project/qgrid/issues
+__ https://github.com/modin-project/modin-spreadsheet#running-from-source--testing-your-changes
+__ https://github.com/modin-project/modin-spreadsheet
+__ https://github.com/modin-project/modin-spreadsheet/issues
 __ https://github.com/

--- a/README.rst
+++ b/README.rst
@@ -142,8 +142,8 @@ to do this.
 
 #. Clone the repository from GitHub and ``cd`` into the top-level directory::
 
-    git clone https://github.com/modin-project/qgrid.git
-    cd qgrid
+    git clone https://github.com/modin-project/modin-spreadsheet.git
+    cd modin-spreadsheet
 
 #. Install the current project in `editable <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_
    mode::

--- a/js/package.json
+++ b/js/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modin-project/qgrid"
+    "url": "https://github.com/modin-project/modin-spreadsheet"
   },
   "keywords": [
     "jupyter",

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ setup_args = {
     "zip_safe": False,
     "author": "Modin Maintainers",
     "author_email": "dev@modin.org",
-    "url": "https://github.com/modin-project/qgrid",
+    "url": "https://github.com/modin-project/modin-spreadsheet",
     "license": "Apache-2.0",
     "keywords": [
         "ipython",


### PR DESCRIPTION
Replaces references to `https://github.com/modin-project/qgrid` with `https://github.com/modin-project/modin-spreadsheet` and replace git clone directory name `qgrid` with `modin-spreadsheet`.

Resolves #22 .